### PR TITLE
Windows fixes

### DIFF
--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -202,7 +202,7 @@ class LanguageServerPlugin : Plugin<Project?> {
             Files.writeString(
                 Paths.get(configuration.outputPath.toString(), "client.js"),
                 """
-                let {LanguageClient} = require("../node_modules/vscode-languageclient/node");
+                let {LanguageClient} = require("./node_modules/vscode-languageclient/node");
         
                 async function activate (context)
                 {
@@ -224,7 +224,7 @@ class LanguageServerPlugin : Plugin<Project?> {
         val npm = if(isWindows()) "npm.cmd" else "npm"
         val npx = if(isWindows()) "npx.cmd" else "npx"
 
-        ProcessBuilder(npm, "install", "--prefix", "build", "vscode-languageclient").directory(project.projectDir).start().waitFor()
+        ProcessBuilder(npm, "install", "--prefix", "build/vscode/", "vscode-languageclient").directory(project.projectDir).start().waitFor()
         ProcessBuilder(npx, "esbuild", "build/vscode/client.js", "--bundle", "--external:vscode", "--format=cjs", "--platform=node", "--outfile=build/vscode/client.js", "--allow-overwrite").directory(project.projectDir).start().waitFor()
 
         if (Files.exists(configuration.textmateGrammarPath)) {


### PR DESCRIPTION
This pull request has two commits:

- the first one fixes `npm` and `npx` commands on Windows
- the second one changes the location of where npm installs the packages (i.e. the `node_modules` directory location). The issue that I encountered is that if you can pass to npm a `--prefix` location that does not contain a package.json it will create an empty one. So, I end up with a node_modules directory under the `build` directory but using the wrong (empty) `package.json`. So, I changed the argument of the `--prefix` option to be the one containing the copied `package.json`.

Let me know if this works for you.