### PR TITLE
Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,25 @@ This repository contains four projects:
 The easiest way to use this library is to:
 
 1. add this repository to the sources where gradle looks for plugins
-2. add the `com.strumenta.kolasu.language-server-plugin` version `1.0.0` to the list of gradle plugins
+2. add the `com.strumenta.kolasu.language-server-plugin` version `x.y.z` to the list of gradle plugins
 3. optionally configure the language server by adding a gradle extension called `languageServer`
 4. run the `createVscodeExtension` gradle task
 5. run the `launchVscodeEditor` gradle task
 
 ## Debugging the language server
 
-By default, the generated language client code, launches the language server with `jvm` with debugger attaching enabled on port 5706.
+To enable debugging, specify the `debugPort` property in the `languageServer` gradle extension. 
+By default, it is set to `null` to run in production mode. 
 
-If using IntelliJ IDEA, one can create a `Remote JVM attach` task that attaches to `localhost:5706`.
+When set to a valid port number, the underlying java process will listen on that port for debugger attachments.
 
-Now, when the editor initializes the server, one may attach the debugger to the server process using this task, and intellij will pop up when a breakpoint is hit while using the editor.
+To attach a debugger from `idea`, create a `Remote JVM Debug` debug configuration with the default configuration, but pointing to the port specified.
+
+Now, run the `launchVscodeExtension` task to open the editor and start the language server process. 
+While the editor is running, one can attach the debugger using the `idea` task and the execution will stop in the language server breakpoints.
+The debugger can be detached and reattached any number of times.
+
+When the language server extension deactivates, for example because the editor is closed, the underlying java process is stopped and also the debugger task if attached.
 
 If interested in debugging the initializing code, one can enable the `suspend` flag in the jvm execution flags. That way the server process will stop until a debugger is attached.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The debugger can be detached and reattached any number of times.
 
 When the language server extension deactivates, for example because the editor is closed, the underlying java process is stopped and also the debugger task if attached.
 
-If interested in debugging the initializing code, one can enable the `suspend` flag in the jvm execution flags. That way the server process will stop until a debugger is attached.
+If interested in debugging the initializing code, one can enable the `suspendExecutionUntilDebuggerAttached` flag in the `languageServer` gradle extension.
+This way, the server process won't start until a debugger is attached.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When set to a valid port number, the underlying java process will listen on that
 
 To attach a debugger from `idea`, create a `Remote JVM Debug` debug configuration with the default configuration, but pointing to the port specified.
 
-Now, run the `launchVscodeExtension` task to open the editor and start the language server process. 
+Now, run the `launchVscodeEditor` task to open the editor and start the language server process. 
 While the editor is running, one can attach the debugger using the `idea` task and the execution will stop in the language server breakpoints.
 The debugger can be detached and reattached any number of times.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.8-SNAPSHOT
+version=1.0.7-SNAPSHOT
 kotlinVersion=1.8.22
 kolasuVersion=1.5.83
 lsp4jVersion=0.24.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.7-SNAPSHOT
+version=1.0.8-SNAPSHOT
 kotlinVersion=1.8.22
 kolasuVersion=1.5.83
 lsp4jVersion=0.24.0

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/Configuration.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/Configuration.kt
@@ -21,4 +21,5 @@ open class Configuration {
     lateinit var packageDefinitionPath: Path
     lateinit var licensePath: Path
     lateinit var outputPath: Path
+    var debugPort: Int? = null
 }

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/Configuration.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/Configuration.kt
@@ -22,4 +22,5 @@ open class Configuration {
     lateinit var licensePath: Path
     lateinit var outputPath: Path
     var debugPort: Int? = null
+    var suspendExecutionUntilDebuggerAttached: Boolean = false
 }

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -280,17 +280,24 @@ class LanguageServerPlugin : Plugin<Project?> {
                 """
                 let {LanguageClient} = require("./node_modules/vscode-languageclient/node");
                 
+                let languageClient;
+                
                 async function activate (context)
                 {
-                    let productionServer = {run: {command: "java", args: $javaProcessArguments}};
+                    let javaProcessInfo = {run: {command: "java", args: $javaProcessArguments}};
                 
-                    let languageClient = new LanguageClient("${configuration.language}", "${configuration.language} language server", productionServer, {documentSelector: ["${configuration.language}"]});
+                    languageClient = new LanguageClient("${configuration.language}", "${configuration.language} language server", javaProcessInfo, {documentSelector: ["${configuration.language}"]});
                     await languageClient.start();
                 
                     context.subscriptions.push(languageClient);
                 }
                 
-                module.exports = {activate};
+                async function deactivate()
+                {
+                    await languageClient?.stop();
+                }
+                
+                module.exports = {activate, deactivate};
                 """.trimIndent()
             )
         }

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -271,6 +271,10 @@ class LanguageServerPlugin : Plugin<Project?> {
                 StandardCopyOption.REPLACE_EXISTING
             )
         } else {
+            var javaProcessArguments = """["-jar", context.asAbsolutePath("server.jar")]"""
+            if (configuration.debugPort != null) {
+                javaProcessArguments = """["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=*:${configuration.debugPort}", "-jar", context.asAbsolutePath("server.jar")]"""
+            }
             Files.writeString(
                 Paths.get(configuration.outputPath.toString(), "client.js"),
                 """
@@ -278,7 +282,7 @@ class LanguageServerPlugin : Plugin<Project?> {
                 
                 async function activate (context)
                 {
-                    let productionServer = {run: {command: "java", args: ["-jar", context.asAbsolutePath("server.jar")]}};
+                    let productionServer = {run: {command: "java", args: $javaProcessArguments}};
                 
                     let languageClient = new LanguageClient("${configuration.language}", "${configuration.language} language server", productionServer, {documentSelector: ["${configuration.language}"]});
                     await languageClient.start();

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -71,6 +71,7 @@ class LanguageServerPlugin : Plugin<Project?> {
         configuration.packageDefinitionPath = Paths.get(projectPath, "src", "main", "resources", "package.json")
         configuration.licensePath = Paths.get(projectPath, "src", "main", "resources", "LICENSE.md")
         configuration.outputPath = Paths.get(projectPath, "build", "vscode")
+        configuration.debugPort = null
 
         val shadowJar = project.tasks.getByName("shadowJar") as ShadowJar
         shadowJar.manifest.attributes["Main-Class"] = "com.strumenta.$language.languageserver.MainKt"

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -72,6 +72,7 @@ class LanguageServerPlugin : Plugin<Project?> {
         configuration.licensePath = Paths.get(projectPath, "src", "main", "resources", "LICENSE.md")
         configuration.outputPath = Paths.get(projectPath, "build", "vscode")
         configuration.debugPort = null
+        configuration.suspendExecutionUntilDebuggerAttached = false
 
         val shadowJar = project.tasks.getByName("shadowJar") as ShadowJar
         shadowJar.manifest.attributes["Main-Class"] = "com.strumenta.$language.languageserver.MainKt"
@@ -273,7 +274,8 @@ class LanguageServerPlugin : Plugin<Project?> {
         } else {
             var javaProcessArguments = """["-jar", context.asAbsolutePath("server.jar")]"""
             if (configuration.debugPort != null) {
-                javaProcessArguments = """["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=*:${configuration.debugPort}", "-jar", context.asAbsolutePath("server.jar")]"""
+                val suspend = if (configuration.suspendExecutionUntilDebuggerAttached) "y" else "n"
+                javaProcessArguments = """["-agentlib:jdwp=transport=dt_socket,server=y,suspend=$suspend,quiet=y,address=*:${configuration.debugPort}", "-jar", context.asAbsolutePath("server.jar")]"""
             }
             Files.writeString(
                 Paths.get(configuration.outputPath.toString(), "client.js"),


### PR DESCRIPTION
These changes enable attaching a debugger to a running language server.
First, update the plugin version and choose a port for the language server to listen for debuggers:
![image](https://github.com/user-attachments/assets/35fec715-e58a-43c1-ae7b-ec7058342cb0)
Next, create a `Remote JVM Debug` task in `idea` pointing to the same port:
![Screenshot from 2025-05-19 12-05-02](https://github.com/user-attachments/assets/e7caf043-ef53-4abb-948d-10f1d9a86746)
Start the editor as usual. While the editor is running, run the `idea` task to attach the debugger to the running language server. Now the code will stop in the breakpoints located in the language server's code:
![Screenshot from 2025-05-19 12-04-23](https://github.com/user-attachments/assets/0d3756cd-647d-4f6c-862f-f06c5bdbc264)

To debug initialization code, set the `suspendExecutionUntilDebuggerAttached` flag to true:
![image](https://github.com/user-attachments/assets/0f6b3fea-7fa2-4c03-a2f8-2145312b2286)
The language server won't start until the debugger task is launched, and you can inspect the initial messages:
![image](https://github.com/user-attachments/assets/3e596d5e-1807-415f-a3ca-e0a68f8c5907)
