### PR TITLE
Improve the kolasu-lsp for Protostar

### DIFF
--- a/library/src/main/kotlin/com/strumenta/kolasu/languageserver/KolasuServer.kt
+++ b/library/src/main/kotlin/com/strumenta/kolasu/languageserver/KolasuServer.kt
@@ -5,6 +5,7 @@ import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Point
 import com.strumenta.kolasu.model.PossiblyNamed
 import com.strumenta.kolasu.model.ReferenceByName
+import com.strumenta.kolasu.model.URLSource
 import com.strumenta.kolasu.model.children
 import com.strumenta.kolasu.model.kReferenceByNameProperties
 import com.strumenta.kolasu.parsing.ASTParser
@@ -269,7 +270,7 @@ open class KolasuServer<T : Node>(
         text: String
     ) {
 
-        val parsingResult = parser?.parse(text) ?: return
+        val parsingResult = parser?.parse(text, source = URLSource(URI.create(uri).toURL())) ?: return
         files[uri] = parsingResult
 
         val tree = parsingResult.root ?: return

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -1,11 +1,18 @@
 package com.strumenta.kolasu.languageserver.plugin
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
 import org.jetbrains.kotlin.konan.file.File
 import java.nio.file.Files
@@ -14,7 +21,9 @@ import java.nio.file.StandardCopyOption
 import java.util.Locale
 
 class LanguageServerPlugin : Plugin<Project?> {
+    private val logger: Logger = Logging.getLogger(javaClass)
     private lateinit var configuration: Configuration
+    val SHADOW_JAR_TASK_NAME = "kolasuLanguageServerJar"
 
     override fun apply(project: Project?) {
         if (project == null) return
@@ -49,7 +58,7 @@ class LanguageServerPlugin : Plugin<Project?> {
         configuration.fileExtensions = mutableListOf(language)
         configuration.editor = "code"
         configuration.textmateGrammarScope = "main"
-        configuration.serverJarPath = Paths.get(projectPath, "build", "libs", "$language.jar")
+        configuration.serverJarPath = Paths.get(projectPath, "build", "libs", "$language-server.jar")
         configuration.examplesPath = Paths.get(project.rootDir.toString(), "examples")
         configuration.entryPointPath =
             Paths.get(
@@ -74,22 +83,48 @@ class LanguageServerPlugin : Plugin<Project?> {
         configuration.debugPort = null
         configuration.suspendExecutionUntilDebuggerAttached = false
 
-        val shadowJar = project.tasks.getByName("shadowJar") as ShadowJar
-        shadowJar.manifest.attributes["Main-Class"] = "com.strumenta.$language.languageserver.MainKt"
-        shadowJar.manifest.attributes["Multi-Release"] = "true"
-        shadowJar.manifest.attributes["Class-Path"] =
-            "lucene-core-${BuildConfig.LUCENE_VERSION}.jar lucene-codecs-${BuildConfig.LUCENE_VERSION}.jar"
-        shadowJar.archiveFileName.set("$language.jar")
-        shadowJar.excludes.add("org/apache/lucene/**/*")
+        val shadowJar = configureShadowTask(project, language)
 
         val testTask = project.tasks.getByName("test") as org.gradle.api.tasks.testing.Test
         testTask.useJUnitPlatform()
 
-        addCreateVscodeExtensionTask(project)
-        addLaunchVscodeEditorTask(project)
+        val createVscodeExtensionTask = addCreateVscodeExtensionTask(project, shadowJar)
+        addLaunchVscodeEditorTask(project, createVscodeExtensionTask)
     }
 
-    private fun addLaunchVscodeEditorTask(project: Project) {
+    protected fun configureShadowTask(project: Project, language: String): TaskProvider<ShadowJar?> {
+        val convention = project.extensions.getByType(JavaPluginExtension::class.java)
+        val shadowJar = project.tasks.register(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) { shadowJar ->
+            // Adapted from ShadowJavaPlugin.configureShadowTask
+            shadowJar.description = "Create a combined JAR of project and runtime dependencies"
+            val jarTask = project.tasks.getByName("jar") as Jar
+            shadowJar.manifest.inheritFrom(jarTask.manifest)
+            shadowJar.manifest.attributes["Main-Class"] = "com.strumenta.$language.languageserver.MainKt"
+            shadowJar.manifest.attributes["Multi-Release"] = "true"
+            shadowJar.manifest.attributes["Class-Path"] =
+                "lucene-core-${BuildConfig.LUCENE_VERSION}.jar lucene-codecs-${BuildConfig.LUCENE_VERSION}.jar"
+            shadowJar.archiveFileName.set("$language-server.jar")
+            shadowJar.excludes.add("org/apache/lucene/**/*")
+            shadowJar.archiveClassifier.set("all")
+            shadowJar.from(convention.sourceSets.getByName("main").output)
+            shadowJar.configurations = listOf(
+                project.configurations.findByName("runtimeClasspath") ?: project.configurations.findByName("runtime")
+            )
+
+            shadowJar.exclude(
+                "META-INF/INDEX.LIST",
+                "META-INF/*.SF",
+                "META-INF/*.DSA",
+                "META-INF/*.RSA",
+                "module-info.class",
+            )
+            shadowJar.dependencies { d -> d.exclude(d.dependency(project.dependencies.gradleApi())) }
+        }
+        project.artifacts.add(ShadowBasePlugin.CONFIGURATION_NAME, shadowJar)
+        return shadowJar
+    }
+
+    private fun addLaunchVscodeEditorTask(project: Project, createVscodeExtensionTask: Task) {
         project.tasks.create("launchVscodeEditor").apply {
             group = "language server"
             description = "Launch the configured vscode editor with the language server installed (defaults to code)"
@@ -104,7 +139,7 @@ class LanguageServerPlugin : Plugin<Project?> {
                         }
                     }
                 )
-            dependsOn(project.tasks.getByName("createVscodeExtension"))
+            dependsOn(createVscodeExtensionTask)
         }
     }
 
@@ -117,8 +152,8 @@ class LanguageServerPlugin : Plugin<Project?> {
         ).directory(project.projectDir).start().waitFor()
     }
 
-    private fun addCreateVscodeExtensionTask(project: Project) {
-        project.tasks.create("createVscodeExtension").apply {
+    private fun addCreateVscodeExtensionTask(project: Project, shadowJarTask: TaskProvider<*>): Task {
+        return project.tasks.create("createVscodeExtension").apply {
             group = "language server"
             description = "Create language server extension folder for vscode under build/vscode"
             actions =
@@ -132,7 +167,7 @@ class LanguageServerPlugin : Plugin<Project?> {
                         }
                     }
                 )
-            dependsOn(project.tasks.getByName("shadowJar"))
+            dependsOn(shadowJarTask)
             inputs.files(
                 configuration.entryPointPath,
                 configuration.textmateGrammarPath,
@@ -147,11 +182,11 @@ class LanguageServerPlugin : Plugin<Project?> {
     }
 
     fun isWindows(): Boolean {
-        return System.getProperty("os.name").toLowerCase().contains("win")
+        return System.getProperty("os.name").lowercase().contains("win")
     }
 
     private fun createVscodeExtension(project: Project) {
-        val shadowJar = project.tasks.getByName("shadowJar") as ShadowJar
+        val shadowJar = project.tasks.getByName(SHADOW_JAR_TASK_NAME) as ShadowJar
         val entryPoint = shadowJar.manifest.attributes["Main-Class"] as String
         if (entryPoint == "com.strumenta.${configuration.language}.languageserver.MainKt") {
             if (!Files.exists(configuration.entryPointPath)) {

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -116,7 +116,7 @@ class LanguageServerPlugin : Plugin<Project?> {
                 "META-INF/*.SF",
                 "META-INF/*.DSA",
                 "META-INF/*.RSA",
-                "module-info.class",
+                "module-info.class"
             )
             shadowJar.dependencies { d -> d.exclude(d.dependency(project.dependencies.gradleApi())) }
         }

--- a/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
+++ b/plugin/src/main/kotlin/com/strumenta/kolasu/languageserver/plugin/LanguageServerPlugin.kt
@@ -99,7 +99,7 @@ class LanguageServerPlugin : Plugin<Project?> {
             shadowJar.description = "Create a combined JAR of project and runtime dependencies"
             val jarTask = project.tasks.getByName("jar") as Jar
             shadowJar.manifest.inheritFrom(jarTask.manifest)
-            shadowJar.manifest.attributes["Main-Class"] = "com.strumenta.$language.languageserver.MainKt"
+            shadowJar.manifest.attributes["Main-Class"] = "${languageServerPackage(language)}.MainKt"
             shadowJar.manifest.attributes["Multi-Release"] = "true"
             shadowJar.manifest.attributes["Class-Path"] =
                 "lucene-core-${BuildConfig.LUCENE_VERSION}.jar lucene-codecs-${BuildConfig.LUCENE_VERSION}.jar"
@@ -123,6 +123,8 @@ class LanguageServerPlugin : Plugin<Project?> {
         project.artifacts.add(ShadowBasePlugin.CONFIGURATION_NAME, shadowJar)
         return shadowJar
     }
+
+    private fun languageServerPackage(language: String): String = "com.strumenta.$language.languageserver"
 
     private fun addLaunchVscodeEditorTask(project: Project, createVscodeExtensionTask: Task) {
         project.tasks.create("launchVscodeEditor").apply {
@@ -188,13 +190,13 @@ class LanguageServerPlugin : Plugin<Project?> {
     private fun createVscodeExtension(project: Project) {
         val shadowJar = project.tasks.getByName(SHADOW_JAR_TASK_NAME) as ShadowJar
         val entryPoint = shadowJar.manifest.attributes["Main-Class"] as String
-        if (entryPoint == "com.strumenta.${configuration.language}.languageserver.MainKt") {
+        if (entryPoint == "${languageServerPackage(configuration.language)}.MainKt") {
             if (!Files.exists(configuration.entryPointPath)) {
                 Files.createDirectories(configuration.entryPointPath.parent)
                 Files.writeString(
                     configuration.entryPointPath,
                     """
-                    package com.strumenta.${configuration.language}.languageserver
+                    package ${languageServerPackage(configuration.language)}
                     
                     import com.strumenta.${configuration.language}.parser.${configuration.language.capitalized()}KolasuParser
                     import com.strumenta.kolasu.languageserver.KolasuServer


### PR DESCRIPTION
- Pass the URI of the file as a Source to the parser (fixes #84)
  - Protostar will use it to resolve imports at the Kolasu level, thus enabling navigation and code completion across files
- Register a separate shadow task to avoid conflicting with the default one (fixes #85)
  - Kolasu-lsp needs to generate a shadow jar (with all dependencies included) to easily launch it as a language server
  - However prior to this PR it used the default `shadowJar` task, and if the host project also wanted to generate a shadow jar, the two would get mixed up, ending up into a single archive with potentially mixed configuration from different sources
  - With this PR we create a dedicated shadow jar task that doesn't conflict with the one created by default by the shadow plugin